### PR TITLE
Execute unequip item plugins

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/action/EquipAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/EquipAction.kt
@@ -188,6 +188,8 @@ object EquipAction {
             val leftover = Item(item, addition.getLeftOver())
             p.equipment.set(equipmentSlot, leftover)
         }
+
+        p.world.plugins.executeUnequipItem(p, item.id)
         return Result.SUCCESS
     }
 }


### PR DESCRIPTION
Unequip item plugins were only being executed when an item is replaced in the equipment container, this commit executes the plugins when an item is unequipped directly from the equipment tab.