### PR TITLE
Fix build dirs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.idea/
 /.gradle/
-/build/
-/out/
+build/
+out/
 
 gradlew
 gradlew.bat


### PR DESCRIPTION
This will make it match `out/` and `build/` anywhere in the repo instead of just the root dir.

Folders such as `/game/build/` were not excluded with the current rule.