### PR TITLE
Add support for binding to an object by name rather than id

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/plugin/KotlinPlugin.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/plugin/KotlinPlugin.kt
@@ -137,6 +137,17 @@ abstract class KotlinPlugin(private val r: PluginRepository, val world: World) {
 
     /**
      * Invoke [logic] when the [option] option is clicked on a
+     * [gg.rsmod.game.model.entity.GameObject] with a specific name
+     */
+    fun on_obj_option(obj: String, option: String, lineOfSightDistance: Int = -1, logic: (Plugin).() -> Unit) {
+        val name = obj.toLowerCase()
+        val opt = option.toLowerCase()
+
+        r.bindObject(obj = name, option = opt, lineOfSightDistance = lineOfSightDistance, plugin = logic)
+    }
+
+    /**
+     * Invoke [logic] when the [option] option is clicked on a
      * [gg.rsmod.game.model.entity.GameObject].
      *
      * This method should be used over the option-int variant whenever possible.

--- a/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/plugin/PluginRepository.kt
@@ -335,14 +335,15 @@ class PluginRepository(val world: World) {
      * Initiates and populates all our plugins.
      */
     fun init(jarPluginsDirectory: String) {
-        setObjectDefs()
+        loadObjectDefs()
+
+        loadPlugins(jarPluginsDirectory)
+
         setCombatDefs()
         spawnEntities()
         setMultiAreas()
         setContainers()
         setShops()
-
-        loadPlugins(jarPluginsDirectory)
     }
 
     internal fun loadPlugins(jarPluginsDirectory: String) {
@@ -396,7 +397,7 @@ class PluginRepository(val world: World) {
         }
     }
 
-    private fun setObjectDefs() {
+    private fun loadObjectDefs() {
         val count = world.definitions.getCount(ObjectDef::class.java)
         for (id in 0 until count) {
             val def = world.definitions.getNullable(ObjectDef::class.java, id)


### PR DESCRIPTION
Useful for objects with have the same name, but many different ids.

```kotlin
on_obj_option(obj = "furnace", option = "smelt") {
    // initiate smelting action
}