### PR TITLE
Simplifying Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   rsmod-server:
-    image: server:latest
+    build: .
     ports:
       - "43594:43594"
     volumes:


### PR DESCRIPTION
## What has been done
**- Replaced the tagged `image: server:latest` tag with `build: .`**
This means that upon `docker-compose up` Docker will build the local `Dockerfile` first. This allows the user to run the server through docker-compose without needing to build and tag the image first.