### PR TITLE
Add Player parameter to produceItemBox logic

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/QueueTaskExt.kt
@@ -294,7 +294,7 @@ suspend fun QueueTask.levelUpMessageBox(skill: Int, levelIncrement: Int) {
     terminateAction!!(this)
 }
 
-suspend fun QueueTask.produceItemBox(vararg items: Int, title: String = "What would you like to make?", maxItems: Int = player.inventory.capacity, logic: (Int, Int) -> Unit) {
+suspend fun QueueTask.produceItemBox(vararg items: Int, title: String = "What would you like to make?", maxItems: Int = player.inventory.capacity, logic: (Player, Int, Int) -> Unit) {
 
     val defs = player.world.definitions
     val itemDefs = items.map { defs.get(ItemDef::class.java, it) }
@@ -325,5 +325,5 @@ suspend fun QueueTask.produceItemBox(vararg items: Int, title: String = "What wo
     val item = items[child - baseChild]
     val qty = msg.slot
 
-    logic(item, qty)
+    logic(player, item, qty)
 }


### PR DESCRIPTION
## What has been done?
A `Player` parameter has been added to the `logic` parameter of `QueueTask.produceItemBox`. This allows users to easily use method references to handle actions rather than relying on the context of the `QueueTask`, ie:

```kotlin
fun smeltItem(player: Player, item: Int, amount: Int) {
    player.message("item=$item, amount=$amount")
}

on_obj_option(obj = 24009, option = "smelt") {
    player.queue { produceItemBox(Items.BRONZE_BAR, title = "What would you like to smelt?", logic = ::smeltItem) }
}
```

## Proposed Changes

  - `logic: (Player, Int, Int) -> Unit`
  -
  -