### PR TITLE
Adds some string and int extension methods

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/IntExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/IntExt.kt
@@ -1,0 +1,38 @@
+package gg.rsmod.plugins.api.ext
+
+/**
+ * @author Triston Plummer ("Dread")
+ */
+
+/**
+ * A map of numbers to English string literals
+ */
+private val numberLiterals = hashMapOf(
+        1 to "one", 2 to "two", 3 to "three", 4 to "four", 5 to "five", 6 to "six",
+        7 to "seven", 8 to "eight", 9 to "nine", 10 to "ten", 11 to "eleven", 12 to "twelve",
+        13 to "thirteen", 14 to "fourteen", 15 to "fifteen", 16 to "sixteen", 17 to "seventeen",
+        18 to "eighteen", 19 to "nineteen", 20 to "twenty", 30 to "thirty", 40 to "forty", 50 to "fifty",
+        60 to "sixty", 70 to "seventy", 80 to "eighty", 90 to "ninety"
+)
+
+/**
+ * Gets the string literal for an integer. If a literal cannot be found, this function
+ * will attempt to generate the literal, and cache the result. Only supports up to 99.
+ *
+ * Example: 73.toLiteral() will produce the value "seventy-three"
+ *
+ * @return      The string literal
+ */
+fun Int.toLiteral() : String? {
+    var literal = numberLiterals[this]
+
+    if (literal == null && this > 20 && this < 100) {
+        val single = (this % 10)
+        val ten = (this - single)
+
+        literal = "${numberLiterals[ten]}-${numberLiterals[single]}"
+        numberLiterals[this] = literal
+    }
+
+    return literal
+}

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/StringExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/StringExt.kt
@@ -4,9 +4,19 @@ package gg.rsmod.plugins.api.ext
  * @author Tom <rspsmods@gmail.com>
  */
 
+private const val vowels = "aeiou"
+
 fun String.plural(amount: Int): String {
     if (endsWith('s')) {
         return this
     }
     return if (amount != 1) this + "s" else this
+}
+
+/**
+ * Prefixes the string with either "a" or "an" depending on whether
+ * the string starts with a vowel
+ */
+fun String.prefixAn() : String {
+    return if (vowels.indexOf(Character.toLowerCase(this[0])) != -1) "an $this" else "a $this"
 }


### PR DESCRIPTION
## What has been done?

String.prefixAn()

Usage:
```kotlin
val name = "adamantite bar".prefixAn() // an adamantite bar
val name = "runite bar".prefixAn() // a runite bar
```

Int.toLiteral()
```kotlin
val literal = 73.toLiteral() // seventy-three
val literal = 22.toLiteral() // twenty-two
```