### PR TITLE
Fix NPC respawning

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/action/NpcDeathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/NpcDeathAction.kt
@@ -39,7 +39,7 @@ object NpcDeathAction {
         deathAnimation.forEach { anim ->
             val def = npc.world.definitions.get(AnimDef::class.java, anim)
             npc.animate(def.id)
-            wait(def.cycleLength)
+            wait(def.cycleLength + 1)
         }
 
         npc.animate(-1)
@@ -48,8 +48,10 @@ object NpcDeathAction {
         world.plugins.executeNpcDeath(npc)
 
         if (npc.respawns) {
-            wait(respawnDelay)
-            world.spawn(Npc(npc.id, npc.spawnTile, world))
+            world.queue {
+                wait(respawnDelay)
+                world.spawn(Npc(npc.id, npc.spawnTile, world))
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, the NPC's queues were being using which means that after the NPC was removed, the execution would just stop on QueueTask#wait.

Also, the animation was always one cycle too short.