### PR TITLE
Trading touch ups

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/trading/impl/TradeStage.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/trading/impl/TradeStage.kt
@@ -17,5 +17,10 @@ enum class TradeStage {
      * Represents a trade session that is currently sitting on the accept screen, where
      * players may agree to complete the trade.
      */
-    ACCEPT_SCREEN
+    ACCEPT_SCREEN,
+
+    /**
+     * Represents a trade session that has been completed
+     */
+    COMPLETED
 }


### PR DESCRIPTION
## What has been done?
"Accepted trade" message added

Trade session marked as 'completed' when players have been given the opposite trade container

Trade session can only 'complete' if it is currently on the accept screen (stops the trade container from potentially being given twice, for whatever reason)

Check added to prevent trades from going through if either player has insufficient inventory space