### PR TITLE
Player shouldn't be locked while smithing

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/action/SmithingAction.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/skills/smithing/action/SmithingAction.kt
@@ -71,11 +71,9 @@ object SmithingAction {
 
             task.wait(2)
 
-            player.lock()
             player.animate(SMITHING_ANIM)
             player.playSound(SMITHING_ANVIL_SOUND)
             task.wait(3)
-            player.unlock()
 
             if (!canSmith(task, meta)) {
                 player.animate(-1)


### PR DESCRIPTION
## What has been done?
Players are no longer locked while performing the smithing action - they can walk away at any point to cancel it, even when halfway through the animation. This is how it is handled on OSRS.