### PR TITLE
ShopItem Prices

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/shops/ItemCurrency.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/shops/ItemCurrency.kt
@@ -39,9 +39,9 @@ open class ItemCurrency(private val currencyItem: Int, private val singularCurre
         return AcceptItemState(acceptable = true, errorMessage = "")
     }
 
-    override fun onSellValueMessage(p: Player, item: Int) {
-        val unnoted = Item(item).toUnnoted(p.world.definitions)
-        val value = getSellPrice(p.world, unnoted.id)
+    override fun onSellValueMessage(p: Player, shopItem: ShopItem) {
+        val unnoted = Item(shopItem.item).toUnnoted(p.world.definitions)
+        val value = shopItem.sellPrice ?: getSellPrice(p.world, unnoted.id)
         val name = unnoted.getName(p.world.definitions)
         val currency = if (value != 1) pluralCurrency else singularCurrency
         p.message("$name: currently costs $value $currency")
@@ -51,7 +51,8 @@ open class ItemCurrency(private val currencyItem: Int, private val singularCurre
         val unnoted = Item(item).toUnnoted(p.world.definitions)
         val acceptance = canAcceptItem(shop, p.world, unnoted.id)
         if (acceptance.acceptable) {
-            val value = getBuyPrice(p.world, unnoted.id)
+            val shopItem = shop.items.filterNotNull().firstOrNull { it.item == item}
+            val value = shopItem?.buyPrice ?: getBuyPrice(p.world, unnoted.id)
             val name = unnoted.getName(p.world.definitions)
             val currency = if (value != 1) pluralCurrency else singularCurrency
             p.message("$name: shop will buy for $value $currency")
@@ -67,7 +68,7 @@ open class ItemCurrency(private val currencyItem: Int, private val singularCurre
     override fun sellToPlayer(p: Player, shop: Shop, slot: Int, amt: Int) {
         val shopItem = shop.items[slot] ?: return
 
-        val currencyCost = getSellPrice(p.world, shopItem.item)
+        val currencyCost = shopItem.sellPrice ?: getSellPrice(p.world, shopItem.item)
         val currencyCount = p.inventory.getItemCount(currencyItem)
 
         var amount = Math.min(Math.floor(currencyCount.toDouble() / currencyCost.toDouble()).toInt(), amt)
@@ -132,7 +133,8 @@ open class ItemCurrency(private val currencyItem: Int, private val singularCurre
         }
 
         val shopSlot = shop.items.indexOfFirst { it?.item == unnoted }
-        val count = if (shopSlot != -1) shop.items[shopSlot]?.currentAmount ?: 0 else 0
+        val shopItem = shop.items[shopSlot]
+        val count = if (shopSlot != -1) shopItem?.currentAmount ?: 0 else 0
 
         val amount = Math.min(Math.min(p.inventory.getItemCount(item.id), amt), Int.MAX_VALUE - count)
 
@@ -146,7 +148,8 @@ open class ItemCurrency(private val currencyItem: Int, private val singularCurre
             return
         }
 
-        val compensation = Math.min(Int.MAX_VALUE.toLong(), getBuyPrice(p.world, unnoted).toLong() * remove.completed.toLong()).toInt()
+        val price = shopItem?.buyPrice ?: getBuyPrice(p.world, unnoted)
+        val compensation = Math.min(Int.MAX_VALUE.toLong(), price.toLong() * remove.completed.toLong()).toInt()
         val add = p.inventory.add(item = currencyItem, amount = compensation, assureFullInsertion = true)
         if (add.requested > 0 && add.completed > 0 || compensation == 0) {
             if (shopSlot != -1) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/shops/shops.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/shops/shops.kts
@@ -36,7 +36,7 @@ on_button(interfaceId = SHOP_INTERFACE_ID, component = 16) {
         val shopItem = shop.items[slot] ?: return@on_button
 
         when (opt) {
-            1 -> shop.currency.onSellValueMessage(player, shopItem.item)
+            1 -> shop.currency.onSellValueMessage(player, shopItem)
             10 -> player.world.sendExamine(player, shopItem.item, ExamineEntityType.ITEM)
             else -> {
                 val amount = when (opt) {

--- a/game/src/main/kotlin/gg/rsmod/game/model/shop/ShopCurrency.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/shop/ShopCurrency.kt
@@ -13,7 +13,7 @@ interface ShopCurrency {
     /**
      * Called when a player selects the "value" option a [ShopItem].
      */
-    fun onSellValueMessage(p: Player, item: Int)
+    fun onSellValueMessage(p: Player, shopItem: ShopItem)
 
     /**
      * Called when a player selects the "value" option on one of their own

--- a/game/src/main/kotlin/gg/rsmod/game/model/shop/ShopItem.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/shop/ShopItem.kt
@@ -23,7 +23,7 @@ package gg.rsmod.game.model.shop
  *
  * @author Tom <rspsmods@gmail.com>
  */
-data class ShopItem(val item: Int, val amount: Int, val sellPrice: Int = -1, val buyPrice: Int = -1,
+data class ShopItem(val item: Int, val amount: Int, val sellPrice: Int? = null, val buyPrice: Int? = null,
                     val resupplyAmount: Int = Shop.DEFAULT_RESUPPLY_AMOUNT,
                     val resupplyCycles: Int = Shop.DEFAULT_RESUPPLY_CYCLES) {
 


### PR DESCRIPTION
## What has been done?
Make use of a ShopItem's `buyPrice` or `sellPrice` if defined, rather than using item definition price.

Issue #78 