### PR TITLE
Added getNeighbourPawns method and implemented Retribution prayer logic

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PawnExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PawnExt.kt
@@ -1,5 +1,7 @@
 package gg.rsmod.plugins.api.ext
 
+import gg.rsmod.game.model.Direction
+import gg.rsmod.game.model.EntityType
 import gg.rsmod.game.model.Hit
 import gg.rsmod.game.model.attr.*
 import gg.rsmod.game.model.entity.GameObject
@@ -100,4 +102,20 @@ fun Pawn.stun(cycles: Int) {
             message("You have been stunned!")
         }
     }
+}
+
+/**
+ * Gets all pawns neighboring this [Pawn].
+ */
+fun Pawn.getNeighbourPawns(): Collection<Pawn> {
+    val neighbourPawns = mutableSetOf<Pawn>()
+
+    Direction.values().forEach { dir ->
+        val step = tile.step(dir)
+        val chunk = world.chunks.get(step) ?: return@forEach
+        val pawns = chunk.getEntities<Pawn>(step, EntityType.CLIENT, EntityType.PLAYER, EntityType.NPC)
+        neighbourPawns.addAll(pawns)
+    }
+
+    return neighbourPawns
 }

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/prayers.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/prayer/prayers.plugin.kts
@@ -1,5 +1,26 @@
 package gg.rsmod.plugins.content.mechanics.prayer
 
+/**
+ * Checks if Retribution is active and deals
+ * ((prayer lvl)/4) damage to nearby enemies
+ */
+on_player_pre_death {
+    if (Prayers.isActive(player, Prayer.RETRIBUTION)) {
+        val targets = player.getNeighbourPawns()
+        loop@ for (target in targets) {
+            when {
+                !target.lock.canBeAttacked() -> continue@loop
+                (target is Player && !target.inWilderness()) -> continue@loop // TODO Check Duel Arena, Castle Wars, Clan Wars
+                target.isDead() -> continue@loop
+                target is Player || (target is Npc && target.def.isAttackable()) -> {
+                    player.graphic(437)
+                    target.hit(damage = (player.getSkills().getCurrentLevel(Skills.PRAYER) / 4))
+                }
+            }
+        }
+    }
+}
+
 on_player_death {
     Prayers.deactivateAll(player)
 }


### PR DESCRIPTION
## What has been done?
Added utility function to find all pawns neighboring a target pawn
Added Retribution prayer logic, should be easily extendable for future cases (i.e. retribution in clan wars, castle wars, etc)

closes #108 