### PR TITLE
fix: player combat level calculation was not updated on client

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -466,6 +466,7 @@ fun Player.calculateAndSetCombatLevel(): Boolean {
     if (changed) {
         runClientScript(389, combatLevel)
         sendCombatLevelText()
+        addBlock(UpdateBlockType.APPEARANCE)
         return true
     }
 


### PR DESCRIPTION
When a player's combat level changed, the right click settings were not updated to reflect the new level differences between the player and other entities.

## What has been done?
The server now sends an appearance block update request on combat level changed events