### PR TITLE
fix: accepting trade request from chatbox request notification

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -49,8 +49,8 @@ fun Player.openShop(shop: String) {
     }
 }
 
-fun Player.message(message: String, type: ChatMessageType = ChatMessageType.CONSOLE) {
-    write(MessageGameMessage(type = type.id, message = message, username = null))
+fun Player.message(message: String, type: ChatMessageType = ChatMessageType.CONSOLE, username: String? = null) {
+    write(MessageGameMessage(type = type.id, message = message, username = username))
 }
 
 fun Player.filterableMessage(message: String) {

--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/trading/trading.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/mechanics/trading/trading.plugin.kts
@@ -48,7 +48,7 @@ on_player_option(option = "Trade with") {
 
         // Send the trade request
         player.message("Sending trade request...")
-        partner.message(TRADE_REQ_STRING.format(player.username), ChatMessageType.TRADE_REQ)
+        partner.message(TRADE_REQ_STRING.format(player.username), ChatMessageType.TRADE_REQ, player.username)
     } else {
 
         // Remove the requests


### PR DESCRIPTION
The message packet supported sending username data but was always set to null. 

## What has been done?
This change modifies the constructor to include an optional username argument which will set the context for the trade request notification and allows the request to be accepted. Thanks to Polar for help with this fix.