### PR TITLE
fix: combat level update doesn't update player info

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -466,6 +466,7 @@ fun Player.calculateAndSetCombatLevel(): Boolean {
     if (changed) {
         runClientScript(389, combatLevel)
         sendCombatLevelText()
+        addBlock(UpdateBlockType.APPEARANCE)
         return true
     }
 


### PR DESCRIPTION
The combat level update check did not include a block update for player appearance and prevented the client from showing accurate menu information involving the player (combat level of player compared to entity on right click).

## What has been done?
This change requests a player appearance block update and fixes the issue. Thanks to polar for help on this fix.