### PR TITLE
fix: follow option being sent as incorrect option index

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/osrs.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/osrs.plugin.kts
@@ -59,7 +59,7 @@ on_login {
     player.syncVarp(OSRSGameframe.PLAYER_ATTACK_PRIORITY_VARP)
 
     // Send player interaction options.
-    player.sendOption("Follow", 1)
+    player.sendOption("Follow", 3)
     player.sendOption("Trade with", 4)
     player.sendOption("Report", 5)
 


### PR DESCRIPTION
The follow option was being sent as option 1 (index 0 after sendOption's subtraction) but should be sent as index 3. Although no issues were noticeable with the index being set to 0, it may cause issues with the addition of attack & duel indexes.

## What has been done?
This change sets the index to 3 (2 after subtraction in sendOption). Thanks to polar for help on this fix.