### PR TITLE
Feat/poison timer fix

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/action/PlayerDeathAction.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/action/PlayerDeathAction.kt
@@ -43,6 +43,7 @@ object PlayerDeathAction {
         player.animate(deathAnim.id)
         wait(deathAnim.cycleLength + 1)
         player.getSkills().restoreAll()
+        player.timers[POISON_TIMER] = 0
         player.animate(-1)
         if (instancedMap == null) {
             // Note: maybe add a player attribute for death locations


### PR DESCRIPTION
## What has been done?
Previously, a player would stay poisoned if they were poisoned before their death. This fix makes the poison timer reset on death.

## Proposed Changes

  - implement a system to identify timers with classifications to be able to mass reset eligible timers on death