### PR TITLE
Update `lever.plugin.kts` to handle teleporting to Ardougne and back.…

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/shared/objs/lever.plugin.kts
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/content/areas/shared/objs/lever.plugin.kts
@@ -1,6 +1,25 @@
-package gg.rsmod.plugins.content.areas.edgeville.objs
+package gg.rsmod.plugins.content.areas.shared.objs
 
 on_obj_option(Objs.LEVER_26761, "pull") {
+    handleLeverInteraction {
+        moveTo(3154, 3924)
+        message("... and teleport into the Wilderness.")
+    }
+}
+on_obj_option(Objs.LEVER_1814, "pull") {
+    handleLeverInteraction {
+        moveTo(3154, 3924)
+        message("... and teleport into the Wilderness.")
+    }
+}
+on_obj_option(Objs.LEVER_9472, "pull") {
+    handleLeverInteraction {
+        moveTo(2561, 3311)
+        message("... and teleport to Ardougne.")
+    }
+}
+
+fun Plugin.handleLeverInteraction(onAnimationComplete: Player.() -> Unit) {
     val obj = player.getInteractingGameObj()
 
     player.queue {
@@ -26,8 +45,7 @@ on_obj_option(Objs.LEVER_26761, "pull") {
         wait(4)
 
         player.animate(-1)
-        player.moveTo(3154, 3924)
-        player.message("... and teleport into the Wilderness.")
+        onAnimationComplete(player)
         player.unlock()
     }
 }


### PR DESCRIPTION
## What has been done?

Updated the `content/areas/edgeville/objs/lever` plugin to handle similar interactions for the wilderness/ardougne corresponding levers.

I figured that it may be a bit weird for the other levers to have their interactions in the `areas/edgeville/` subfolder, so I also moved it to `areas/shared/`

## Proposed Changes

  - Create an `areas/shared/objs/` space for object interactions sharing code which span multiple areas.
  - Implement Ardougne and Wilderness lever functionality.