### PR TITLE
Stop despawning permanent ground items

### DIFF
--- a/game/src/main/kotlin/gg/rsmod/game/model/World.kt
+++ b/game/src/main/kotlin/gg/rsmod/game/model/World.kt
@@ -266,7 +266,7 @@ class World(val gameContext: GameContext, val devContext: DevContext) {
 
             groundItem.currentCycle++
 
-            if (groundItem.isPublic() && groundItem.currentCycle >= gameContext.gItemDespawnDelay) {
+            if (groundItem.isPublic() && groundItem.currentCycle >= gameContext.gItemDespawnDelay && groundItem.respawnCycles == -1) {
                 /*
                  * If the ground item is public and its cycle count has reached the
                  * despawn delay set by our game, we add it to our removal queue.


### PR DESCRIPTION
## What has been done?
Permanent ground items will no longer be despawned. This solves a performance issue where the cycle time would increase significantly over time, due to a large number of ground items being spawned unnecessarily.